### PR TITLE
Add Extreme case on faculties

### DIFF
--- a/utils/u_detail.py
+++ b/utils/u_detail.py
@@ -24,6 +24,7 @@ DEL_TAG = re.compile(r"<[^>]+?>.*<\/[^>]+>")
 H3 = re.compile(r"<h3[^>]*>(.*?)<\/h3>")
 LI = re.compile(r"<li>(.*?)<\/li>")
 TAG_CONTENT= re.compile(r"<[^>]+?>(.*)<\/[^>]+?>")
+SPECIALIZED_PTAG = re.compile(r"specialized in ([^\.]*?)\.", re.S)
 
 HREF_HTTP = re.compile(r'(?i)<a[^>]*\bhref\s*=\s*(["\'])(https?://.*?)\1')
 KEYWORDS = re.compile(r"(?i)(?:wiki|\.com|\?|&|\.net)")
@@ -134,6 +135,17 @@ def _extract_faculties(html):
                     dl.append(content.group(1))
                 else:
                     dl.append(li)
+        if not dl:
+            at = 3
+            content = SPECIALIZED_PTAG.search(section)
+            if content:
+                faculties = content.group(1).split(',')
+                for faculty in faculties:
+                    if "and" in faculty:
+                        dl.append(faculty.split("and")[1].strip())
+                    else:
+                        dl.append(faculty.strip())
+
         dl = [DEL_TAG.sub("", d).strip() for d in dl]
         print(dl, at)
         result = dl


### PR DESCRIPTION
This pull request updates the faculty extraction logic in `utils/u_detail.py` to better handle cases where faculty information is provided in a sentence format, such as "specialized in X, Y and Z." The main improvement is the addition of a new regular expression and parsing branch to extract faculty names from such sentences.

Enhancements to faculty extraction:

* Added the `SPECIALIZED_PTAG` regular expression to detect and extract faculty names from sentences like "specialized in ...".
* Updated the `_extract_faculties` function to use the new regex when the regular list-based extraction fails, splitting faculty names by commas and "and" for more robust parsing.